### PR TITLE
Fix crash on "endofscreen" clearing

### DIFF
--- a/library/minitel/decoder.js
+++ b/library/minitel/decoder.js
@@ -351,7 +351,7 @@ Minitel.Decoder = class extends Minitel.Protocol {
 
         if(clearRange === "endofscreen") {
             // Clear from the current cursor position till the end of the screen
-            this.vdu.cursorToEndOfScreen((x, y) => {
+            this.vdu.cursor.cursorToEndOfScreen((x, y) => {
                 this.vdu.set(x, y, new Minitel.MosaicCell())
             })
 


### PR DESCRIPTION
I got this error while trying to clear a screen from cursor to the end:

```
Uncaught TypeError: this.vdu.cursorToEndOfScreen is not a function
    clear http://www.minipavi.fr/emulminitel/library/minitel/decoder.js:354
    decode http://www.minipavi.fr/emulminitel/library/minitel/protocol.js:388
    decodeList http://www.minipavi.fr/emulminitel/library/minitel/protocol.js:409
    <anonymous> http://www.minipavi.fr/emulminitel/library/generichelper/generichelper.js:63
    decodeList http://www.minipavi.fr/emulminitel/library/minitel/protocol.js:408
    sendChunk http://www.minipavi.fr/emulminitel/library/minitel/minitel-emulator.js:293
    timer http://www.minipavi.fr/emulminitel/library/minitel/minitel-emulator.js:246
```

The function exists it's just in another object.

Also, thanks a lot for this project!